### PR TITLE
added shade and FatJarLauncher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,27 @@
             <artifactId>javafx-web</artifactId>
             <version>${javafx.version}</version>
         </dependency>
+
+        <!-- adding all the platform libs only adds a couple more MB -->
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-graphics</artifactId>
+            <version>${javafx.version}</version>
+            <classifier>win</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-graphics</artifactId>
+            <version>${javafx.version}</version>
+            <classifier>mac</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-graphics</artifactId>
+            <version>${javafx.version}</version>
+            <classifier>linux</classifier>
+        </dependency>
+
         <dependency>
             <groupId>org.controlsfx</groupId>
             <artifactId>controlsfx</artifactId>
@@ -117,21 +138,19 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.openjfx</groupId>
-                <artifactId>javafx-maven-plugin</artifactId>
-                <version>0.0.8</version>
+                <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>
-                        <!-- Default configuration for running with: mvn clean javafx:run -->
-                        <id>default-cli</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
                         <configuration>
-                            <mainClass>com.example.threefatftw.HelloApplication</mainClass>
-                            <launcher>app</launcher>
-                            <jlinkZipName>app</jlinkZipName>
-                            <jlinkImageName>app</jlinkImageName>
-                            <noManPages>true</noManPages>
-                            <stripDebug>true</stripDebug>
-                            <noHeaderFiles>true</noHeaderFiles>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.example.threefatftw.FatJarLauncher</mainClass>
+                                </transformer>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/com/example/threefatftw/FatJarLauncher.java
+++ b/src/main/java/com/example/threefatftw/FatJarLauncher.java
@@ -1,0 +1,16 @@
+package com.example.threefatftw;
+
+public class FatJarLauncher {
+
+    // Shade, Assembly, and other plugins mess with the jar structure and ... threads?
+    // and i dont fully understand it but we require this little shim
+    // https://stackoverflow.com/questions/52653836/maven-shade-javafx-runtime-components-are-missing
+    // this can be reworked once you move to modules.
+    // more reading here:
+    // https://edencoding.com/runtime-components-error/
+
+    public static void main(String[] args) {
+        HelloApplication.main(args);
+    }
+
+}

--- a/src/main/java/com/example/threefatftw/Test.java
+++ b/src/main/java/com/example/threefatftw/Test.java
@@ -1,6 +1,0 @@
-package com.example.threefatftw;
-class Test{
-    public static void main(){
-        System.out.println("aaaaaaaaa");
-    }
-}


### PR DESCRIPTION
the FatJarLauncher can be used from within the IDE and also referenced by the jar to make it easier to launch JavaFX fatjars 